### PR TITLE
Support multiples admins

### DIFF
--- a/frontend/src/components/ui/ProjectMembership.vue
+++ b/frontend/src/components/ui/ProjectMembership.vue
@@ -1,7 +1,7 @@
 <template>
   <v-dialog v-model="dialog" max-width="500px">
     <template v-slot:activator="{ on, attrs }">
-      <v-btn color="secondary" text v-bind="attrs" v-on="on"> <v-icon>mdi-pencil</v-icon> edit </v-btn>
+      <v-btn v-if="admin" color="secondary" text v-bind="attrs" v-on="on"> <v-icon>mdi-pencil</v-icon> edit </v-btn>
     </template>
     <message-dialog v-model="errorDialog" type="error">{{ errorMessage }}</message-dialog>
     <v-card>
@@ -14,8 +14,26 @@
             <v-list-item v-if="admin">
               <v-text-field v-model="githubTemplate" label="Github Template" clearable />
             </v-list-item>
-            <v-list-item>
-              <v-combobox v-model="members" label="Members" multiple chips append-icon deletable-chips />
+            <v-subheader>Members</v-subheader>
+            <v-list-item v-for="entry in entries" :key="entry.username" dense>
+              <v-list-item-content>{{ entry.username }}</v-list-item-content>
+              <v-list-item-action>
+                <v-tooltip bottom>
+                  <template #activator="{ on, attrs }">
+                    <v-simple-checkbox
+                      v-model="entry.isAdmin"
+                      v-bind="attrs"
+                      v-on="on"
+                    />
+                  </template>
+                  <span>Admin</span>
+                </v-tooltip>
+              </v-list-item-action>
+              <v-list-item-action>
+                <v-btn icon small @click="removeMember(entry.username)">
+                  <v-icon small>mdi-delete</v-icon>
+                </v-btn>
+              </v-list-item-action>
             </v-list-item>
             <v-list-item>
               <v-text-field
@@ -24,10 +42,17 @@
                 type="text"
                 clearable
                 filled
-                label="Add a new member"
+                label="Add a member"
+                hint="Check the box to make them admin"
                 @click:append-outer="addMember"
                 v-on:keyup.enter="addMember"
               />
+              <v-tooltip bottom>
+                <template #activator="{ on, attrs }">
+                  <v-simple-checkbox v-model="newMemberIsAdmin" class="ml-2" v-bind="attrs" v-on="on" />
+                </template>
+                <span>Admin</span>
+              </v-tooltip>
             </v-list-item>
           </v-list>
         </v-container>
@@ -49,14 +74,8 @@ export default {
   name: "ProjectMembership",
   components: { MessageDialog },
   props: {
-    id: {
-      type: Number,
-      required: true,
-    },
-    admin: {
-      type: Boolean,
-      default: false,
-    },
+    id: { type: Number, required: true },
+    admin: { type: Boolean, default: false },
   },
   data() {
     return {
@@ -64,8 +83,9 @@ export default {
       errorDialog: false,
       errorMessage: "",
       project: {},
-      members: [],
+      entries: [], // [{ username, isAdmin }]
       newMember: "",
+      newMemberIsAdmin: false,
       githubTemplate: "",
     };
   },
@@ -73,7 +93,11 @@ export default {
     async dialog(val) {
       if (val) {
         this.project = (await ProjectRepository.get(this.id)).data;
-        this.members = [...this.project.members];
+        const adminSet = new Set(this.project.admins);
+        this.entries = this.project.members.map((username) => ({
+          username,
+          isAdmin: adminSet.has(username),
+        }));
         this.githubTemplate = this.project.github_template;
       } else {
         this.close();
@@ -82,17 +106,27 @@ export default {
   },
   methods: {
     addMember() {
-      if (this.newMember !== "") {
-        this.members.push(this.newMember);
+      if (this.newMember && !this.entries.find((e) => e.username === this.newMember)) {
+        this.entries.push({ username: this.newMember, isAdmin: this.newMemberIsAdmin });
         this.newMember = "";
+        this.newMemberIsAdmin = false;
       }
     },
+    removeMember(username) {
+      this.entries = this.entries.filter((e) => e.username !== username);
+    },
     async save() {
-      const old_members = new Set(this.project.members);
-      const new_members = new Set(this.members);
-      const add_members = [...new_members].filter((x) => !old_members.has(x));
-      const del_members = [...old_members].filter((x) => !new_members.has(x));
-      const payload = { add: add_members, del: del_members };
+      const oldMembers = new Set(this.project.members);
+      const oldAdmins = new Set(this.project.admins);
+      const newMembers = new Set(this.entries.map((e) => e.username));
+      const newAdmins = new Set(this.entries.filter((e) => e.isAdmin).map((e) => e.username));
+
+      const payload = {
+        add: [...newMembers].filter((x) => !oldMembers.has(x)),
+        del: [...oldMembers].filter((x) => !newMembers.has(x)),
+        add_admins: [...newAdmins].filter((x) => !oldAdmins.has(x)),
+        del_admins: [...oldAdmins].filter((x) => !newAdmins.has(x)),
+      };
       if (this.admin && this.githubTemplate !== this.project.github_template) {
         payload.github_template = this.githubTemplate ?? "";
       }
@@ -107,7 +141,9 @@ export default {
     },
     close() {
       this.project = {};
-      this.members = [];
+      this.entries = [];
+      this.newMember = "";
+      this.newMemberIsAdmin = false;
       this.githubTemplate = "";
       this.dialog = false;
     },

--- a/mchub/models/cloud/project.py
+++ b/mchub/models/cloud/project.py
@@ -17,15 +17,36 @@ class Provider(str, enum.Enum):
     OVH = "ovh"
 
 
+project_admins = db.Table(
+    "project_admins",
+    db.Column("user_id", db.Integer, db.ForeignKey("user.id"), primary_key=True),
+    db.Column("project_id", db.Integer, db.ForeignKey("project.id"), primary_key=True),
+)
+
+
 class Project(db.Model):
     __tablename__ = "project"
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(), nullable=False)
-    admin_id = db.Column(db.Integer, nullable=False)
     provider = db.Column(db.Enum(Provider), nullable=False)
     github_template = db.Column(db.String(), nullable=False)
     env = db.Column(db.PickleType())
     tfcloud_project_id = db.Column(db.String(), nullable=False)
+    admins = db.relationship(
+        "UserORM",
+        secondary=project_admins,
+        lazy="subquery",
+        cascade_backrefs=False,
+    )
+    @property
+    def members(self):
+        seen = {u.id for u in self.admins}
+        result = list(self.admins)
+        for u in self._direct_members:
+            if u.id not in seen:
+                result.append(u)
+        return result
+
     magic_castles = db.relationship(
         "MagicCastleORM",
         back_populates="project",

--- a/mchub/models/magic_castle/magic_castle.py
+++ b/mchub/models/magic_castle/magic_castle.py
@@ -186,6 +186,7 @@ class MagicCastleORM(db.Model):
     config = db.Column(db.PickleType())
     applied_config = db.Column(db.PickleType())
     eyaml_public_key = db.Column(db.Text)
+    created_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
     project_id = db.Column(db.Integer, db.ForeignKey("project.id"))
     project = db.relationship(
         "Project",
@@ -475,10 +476,11 @@ class MagicCastle:
             var_tf["hieradata"] = f"{existing}\n{proxy_hieradata}" if existing else proxy_hieradata
         return var_tf
 
-    def plan_creation(self, data):
+    def plan_creation(self, data, created_by_user_id=None):
         logger.debug(f"Call <{type(self).__name__}>:plan_creation")
 
         self.set_configuration(data)
+        self.orm.created_by_user_id = created_by_user_id
         db.session.add(self.orm)
         try:
             db.session.commit()

--- a/mchub/models/user.py
+++ b/mchub/models/user.py
@@ -5,7 +5,7 @@ from getpass import getuser
 from .magic_castle.magic_castle import MagicCastle, MagicCastleORM
 from ..configuration import get_config
 from ..database import db
-from .cloud.project import Project
+from .cloud.project import Project, project_admins
 
 
 projects = db.Table(
@@ -23,7 +23,7 @@ class UserORM(db.Model):
         "Project",
         secondary=projects,
         lazy="subquery",
-        backref=db.backref("members", lazy=True),
+        backref=db.backref("_direct_members", lazy=True),
         order_by="Project.id",
         cascade_backrefs=False,
     )
@@ -56,17 +56,40 @@ class User:
     def is_admin(self):
         return self.orm.scoped_id in get_config().get("admins", [])
 
+    def is_project_admin(self, project):
+        return self.orm in project.admins
+
+    def can_access_cluster(self, orm):
+        return self.is_project_admin(orm.project) or orm.created_by_user_id == self.orm.id
+
     @property
     def projects(self):
-        return self.orm.projects
+        direct = self.orm.projects
+        direct_ids = {p.id for p in direct}
+        admin_projects = db.session.scalars(
+            db.select(Project)
+            .join(project_admins, project_admins.c.project_id == Project.id)
+            .where(project_admins.c.user_id == self.orm.id)
+        ).all()
+        result = list(direct)
+        for p in admin_projects:
+            if p.id not in direct_ids:
+                result.append(p)
+        return result
 
     @property
     def magic_castles(self):
-        return [
-            MagicCastle(orm=mc_orm)
-            for project in self.projects
-            for mc_orm in project.magic_castles
-        ]
+        result = []
+        for project in self.projects:
+            if self.is_project_admin(project):
+                result.extend([MagicCastle(orm=mc_orm) for mc_orm in project.magic_castles])
+            else:
+                result.extend([
+                    MagicCastle(orm=mc_orm)
+                    for mc_orm in project.magic_castles
+                    if mc_orm.created_by_user_id == self.orm.id
+                ])
+        return result
 
 
 class LocalUser(User):
@@ -90,6 +113,12 @@ class LocalUser(User):
 
     @property
     def is_admin(self):
+        return True
+
+    def is_project_admin(self, project):
+        return True
+
+    def can_access_cluster(self, orm):
         return True
 
 

--- a/mchub/resources/magic_castle_api.py
+++ b/mchub/resources/magic_castle_api.py
@@ -71,7 +71,7 @@ class MagicCastleAPI(ApiView):
             orm = db.session.execute(
                 db.select(MagicCastleORM).filter_by(hostname=hostname)
             ).scalar_one_or_none()
-            if orm and orm.project in user.projects:
+            if orm and orm.project in user.projects and user.can_access_cluster(orm):
                 return MagicCastle(orm).state
             else:
                 raise ClusterNotFoundException
@@ -84,7 +84,7 @@ class MagicCastleAPI(ApiView):
             orm = db.session.execute(
                 db.select(MagicCastleORM).filter_by(hostname=hostname)
             ).scalar_one_or_none()
-            if not (orm and orm.project in user.projects):
+            if not (orm and orm.project in user.projects and user.can_access_cluster(orm)):
                 raise ClusterNotFoundException
 
             def apply_cluster(hostname):
@@ -107,14 +107,15 @@ class MagicCastleAPI(ApiView):
             if project and project not in user.projects:
                 raise InvalidUsageException("Invalid project id")
 
-            self._run_in_background(app, MagicCastle().plan_creation, json_data)
+            user_id = user.orm.id
+            self._run_in_background(app, MagicCastle().plan_creation, json_data, user_id)
             return {}, 202
 
     def put(self, user: User, hostname):
         orm = db.session.execute(
             db.select(MagicCastleORM).filter_by(hostname=hostname)
         ).scalar_one_or_none()
-        if not (orm and orm.project in user.projects):
+        if not (orm and orm.project in user.projects and user.can_access_cluster(orm)):
             raise ClusterNotFoundException
 
         json_data = request.get_json()
@@ -140,7 +141,7 @@ class MagicCastleAPI(ApiView):
         orm = db.session.execute(
             db.select(MagicCastleORM).filter_by(hostname=hostname)
         ).scalar_one_or_none()
-        if not (orm and orm.project in user.projects):
+        if not (orm and orm.project in user.projects and user.can_access_cluster(orm)):
             raise ClusterNotFoundException
 
         app = current_app._get_current_object()

--- a/mchub/resources/project_api.py
+++ b/mchub/resources/project_api.py
@@ -19,17 +19,21 @@ class ProjectAPI(ApiView):
     def get(self, user: User, id: int = None):
         if id is not None:
             project = db.session.get(Project, id)
-            if project is None or project not in user.orm.projects:
+            if project is None or project not in user.projects:
                 raise InvalidUsageException("Invalid project id")
+            is_admin = user.is_project_admin(project)
             return {
                 "id": project.id,
                 "name": project.name,
                 "provider": project.provider,
                 "github_template": project.github_template,
                 "nb_clusters": len(project.magic_castles),
-                "admin": project.admin_id == user.orm.id,
+                "admin": is_admin,
                 "members": [member.scoped_id for member in project.members]
-                if project.admin_id == user.orm.id
+                if is_admin
+                else [],
+                "admins": [admin.scoped_id for admin in project.admins]
+                if is_admin
                 else [],
             }
         else:
@@ -40,7 +44,7 @@ class ProjectAPI(ApiView):
                     "provider": project.provider,
                     "github_template": project.github_template,
                     "nb_clusters": len(project.magic_castles),
-                    "admin": project.admin_id == user.orm.id,
+                    "admin": user.is_project_admin(project),
                 }
                 for project in user.projects
             ]
@@ -96,13 +100,12 @@ class ProjectAPI(ApiView):
 
         project = Project(
             name=name,
-            admin_id=user.orm.id,
             provider=provider,
             env=env,
             github_template=github_template,
             tfcloud_project_id=tfcloud_project_id,
         )
-        user.orm.projects.append(project)
+        project.admins.append(user.orm)
         db.session.add(project)
         db.session.commit()
         return {
@@ -111,14 +114,14 @@ class ProjectAPI(ApiView):
             "provider": project.provider,
             "github_template": project.github_template,
             "nb_clusters": len(project.magic_castles),
-            "admin": project.admin_id == user.orm.id,
+            "admin": True,
         }, 200
 
     def patch(self, user: User, id: int):
         project = db.session.get(Project, id)
-        if project is None or project not in user.orm.projects:
+        if project is None or project not in user.projects:
             raise InvalidUsageException("Invalid project id")
-        if project.admin_id != user.orm.id:
+        if not user.is_project_admin(project):
             raise InvalidUsageException(
                 "Cannot edit project membership that you are not the admin of"
             )
@@ -127,10 +130,6 @@ class ProjectAPI(ApiView):
             raise InvalidUsageException("No json data was provided")
 
         if "github_template" in data:
-            if project.admin_id != user.orm.id:
-                raise InvalidUsageException(
-                    "Cannot edit github template of a project you are not the admin of"
-                )
             if data["github_template"]:
                 try:
                     get_github_storage().validate_template(data["github_template"])
@@ -140,6 +139,8 @@ class ProjectAPI(ApiView):
 
         add_members = data.get("add", [])
         del_members = data.get("del", [])
+        add_admins = data.get("add_admins", [])
+        del_admins = data.get("del_admins", [])
 
         default_domain = user.domain
 
@@ -152,7 +153,8 @@ class ProjectAPI(ApiView):
             if not member:
                 member = UserORM(scoped_id=username)
                 db.session.add(member)
-            member.projects.append(project)
+            if project not in member.projects:
+                member.projects.append(project)
 
         for username in del_members:
             if "@" not in username:
@@ -161,16 +163,44 @@ class ProjectAPI(ApiView):
                 db.select(UserORM).filter_by(scoped_id=username)
             ).scalar_one_or_none()
             if member and member.id != user.orm.id:
+                if project in member.projects:
+                    member.projects.remove(project)
+                if member in project.admins:
+                    project.admins.remove(member)
+
+        for username in add_admins:
+            if "@" not in username:
+                username = f"{username}@{default_domain}"
+            member = db.session.execute(
+                db.select(UserORM).filter_by(scoped_id=username)
+            ).scalar_one_or_none()
+            if not member:
+                member = UserORM(scoped_id=username)
+                db.session.add(member)
+            if project in member.projects:
                 member.projects.remove(project)
+            if member not in project.admins:
+                project.admins.append(member)
+
+        for username in del_admins:
+            if "@" not in username:
+                username = f"{username}@{default_domain}"
+            member = db.session.execute(
+                db.select(UserORM).filter_by(scoped_id=username)
+            ).scalar_one_or_none()
+            if member and member.id != user.orm.id and member in project.admins:
+                project.admins.remove(member)
+                if project not in member.projects:
+                    member.projects.append(project)
 
         db.session.commit()
         return {}, 200
 
     def delete(self, user: User, id: int):
         project = db.session.get(Project, id)
-        if project is None or project not in user.orm.projects:
+        if project is None or project not in user.projects:
             raise InvalidUsageException("Invalid project id")
-        if project.admin_id != user.orm.id:
+        if not user.is_project_admin(project):
             raise InvalidUsageException(
                 "Cannot remove project that you are not the admin of"
             )

--- a/migrations/versions/0004_multi_admin_and_cluster_owner.py
+++ b/migrations/versions/0004_multi_admin_and_cluster_owner.py
@@ -1,0 +1,52 @@
+"""Add project_admins table and cluster created_by_user_id; migrate from admin_id
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-04-28 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Create the project_admins join table
+    op.create_table(
+        "project_admins",
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("user.id"), primary_key=True),
+        sa.Column("project_id", sa.Integer, sa.ForeignKey("project.id"), primary_key=True),
+    )
+
+    # Migrate existing admin_id values into project_admins
+    bind = op.get_bind()
+    rows = bind.execute(sa.text("SELECT id, admin_id FROM project WHERE admin_id IS NOT NULL")).fetchall()
+    for project_id, admin_id in rows:
+        bind.execute(
+            sa.text("INSERT OR IGNORE INTO project_admins (user_id, project_id) VALUES (:uid, :pid)"),
+            {"uid": admin_id, "pid": project_id},
+        )
+
+    # Add created_by_user_id to magiccastle
+    with op.batch_alter_table("magiccastle") as batch_op:
+        batch_op.add_column(sa.Column("created_by_user_id", sa.Integer, nullable=True))
+        batch_op.create_foreign_key("fk_magiccastle_created_by_user_id", "user", ["created_by_user_id"], ["id"])
+
+    # Drop the now-replaced admin_id column from project
+    with op.batch_alter_table("project") as batch_op:
+        batch_op.drop_column("admin_id")
+
+
+def downgrade():
+    with op.batch_alter_table("project") as batch_op:
+        batch_op.add_column(sa.Column("admin_id", sa.Integer, nullable=True))
+
+    with op.batch_alter_table("magiccastle") as batch_op:
+        batch_op.drop_column("created_by_user_id")
+
+    op.drop_table("project_admins")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -59,7 +59,6 @@ def app(config_mock, generate_test_clusters):
 
         project_alice = Project(
             name="project-alice",
-            admin_id=alice_user.id,
             provider="openstack",
             env={
                 "OS_AUTH_URL": "http://localhost:5000/v3",
@@ -72,7 +71,6 @@ def app(config_mock, generate_test_clusters):
         project_bob = Project(
             name="project-bob",
             provider="openstack",
-            admin_id=bob_user.id,
             env={
                 "OS_AUTH_URL": "http://localhost:5000/v3",
                 "OS_APPLICATION_CREDENTIAL_ID": "'z3vjwfkwqocqo2kpowkxf50uvjfkqeqt'",
@@ -81,10 +79,10 @@ def app(config_mock, generate_test_clusters):
             github_template="github_template",
             tfcloud_project_id="tfcloud_id",
         )
+        project_alice.admins.append(alice_user)
+        project_bob.admins.append(bob_user)
         local_user.projects.append(project_alice)
         local_user.projects.append(project_bob)
-        alice_user.projects.append(project_alice)
-        bob_user.projects.append(project_bob)
         db.session.add(project_alice)
         db.session.add(project_bob)
         db.session.commit()


### PR DESCRIPTION
Support for multiples admin and members.

Members can create cluster in the project but they don't have access to other clusters in the project. They cannot edit the project.

Admin can see all clusters in a project and edit the project.