### PR TITLE
Fix the cluster-destruction completion flow

### DIFF
--- a/frontend/src/components/cluster/ClusterDisplay.vue
+++ b/frontend/src/components/cluster/ClusterDisplay.vue
@@ -193,16 +193,16 @@ export default {
 
       if (!this.busy) {
         this.stopStatusPolling();
+        if ([ClusterStatusCode.DESTROY_SUCCESS, ClusterStatusCode.NOT_FOUND].includes(status)) {
+          this.goHome();
+          return;
+        }
         if (statusAlreadyInitialized && !planWasRunning) {
           // We avoid displaying any status dialog after plan generation,
           // because the new status may be the same as before the plan creation.
           this.showStatusDialog();
         }
-        if (status == ClusterStatusCode.NOT_FOUND) {
-          this.goHome();
-        } else {
-          await this.loadCluster();
-        }
+        await this.loadCluster();
       }
     },
     startStatusPolling() {

--- a/frontend/src/components/ui/StatusChip.vue
+++ b/frontend/src/components/ui/StatusChip.vue
@@ -16,6 +16,7 @@ const ClusterFormattedStatus = Object.freeze({
   build_error: { text: "Build error", color: "red" },
   destroy_running: { text: "Destroy running", color: "orange" },
   destroy_error: { text: "Destroy error", color: "red" },
+  destroy_success: { text: "Destroyed", color: "green" },
   not_found: { text: "Not found", color: "purple" },
 });
 

--- a/frontend/src/models/ClusterStatusCode.js
+++ b/frontend/src/models/ClusterStatusCode.js
@@ -9,5 +9,6 @@ export default Object.freeze({
   BUILD_ERROR: "build_error",
   DESTROY_RUNNING: "destroy_running",
   DESTROY_ERROR: "destroy_error",
+  DESTROY_SUCCESS: "destroy_success",
   NOT_FOUND: "not_found",
 });

--- a/frontend/tests/unit/components/cluster/ClusterDisplay.spec.js
+++ b/frontend/tests/unit/components/cluster/ClusterDisplay.spec.js
@@ -1,0 +1,45 @@
+import ClusterDisplay from "@/components/cluster/ClusterDisplay";
+import ClusterStatusCode from "@/models/ClusterStatusCode";
+import MagicCastleRepository from "@/repositories/MagicCastleRepository";
+
+jest.mock("@/repositories/MagicCastleRepository", () => ({
+  getStatus: jest.fn(),
+}));
+
+describe("ClusterDisplay", () => {
+  it("returns home without reloading a successfully destroyed cluster", async () => {
+    MagicCastleRepository.getStatus.mockResolvedValue({
+      data: {
+        status: ClusterStatusCode.DESTROY_SUCCESS,
+        stateful: false,
+      },
+    });
+
+    const context = {
+      statusPromise: null,
+      status: ClusterStatusCode.DESTROY_RUNNING,
+      stateful: true,
+      resourcesChanges: [],
+      stopStatusPolling: jest.fn(),
+      showStatusDialog: jest.fn(),
+      goHome: jest.fn(),
+      loadCluster: jest.fn(),
+    };
+    Object.defineProperty(context, "busy", {
+      get() {
+        return [
+          ClusterStatusCode.DESTROY_RUNNING,
+          ClusterStatusCode.BUILD_RUNNING,
+          ClusterStatusCode.PLAN_RUNNING,
+        ].includes(this.status);
+      },
+    });
+
+    await ClusterDisplay.methods.fetchStatus.call(context);
+
+    expect(context.stopStatusPolling).toHaveBeenCalled();
+    expect(context.goHome).toHaveBeenCalled();
+    expect(context.showStatusDialog).not.toHaveBeenCalled();
+    expect(context.loadCluster).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
  - destroy_success now redirects immediately to the cluster list.
  - The deleted cluster state is no longer fetched, preventing the “Cluster does not exist” dialog.
  - Added a “Destroyed” status mapping as a safe fallback.
  - Added a regression test in frontend/tests/unit/components/cluster/ClusterDisplay.spec.js.