### PR TITLE
Implement data-driven service rendering

### DIFF
--- a/frontend/src/components/cluster/ClustersList.vue
+++ b/frontend/src/components/cluster/ClustersList.vue
@@ -82,28 +82,24 @@
               <v-divider class="mt-4" />
               <v-row class="pa-2">
                 <v-btn
+                  v-for="(service, serviceName) in item.services"
+                  :key="serviceName"
                   color="primary"
                   :disabled="item.status !== 'provisioning_success'"
                   text
-                  :href="`https://jupyter.${item.hostname}`"
+                  :href="service.url"
                   target="_blank"
-                  >JupyterHub
-                </v-btn>
-                <v-btn
-                  color="primary"
-                  :disabled="item.status !== 'provisioning_success'"
-                  text
-                  :href="`https://ipa.${item.hostname}`"
-                  target="_blank"
-                  >FreeIPA
-                </v-btn>
-                <v-btn
-                  color="primary"
-                  :disabled="item.status !== 'provisioning_success'"
-                  text
-                  :href="`https://mokey.${item.hostname}`"
-                  target="_blank"
-                  >Mokey
+                >
+                  <v-icon
+                    x-small
+                    class="mr-2"
+                    :color="serviceStatusColor(service)"
+                    :aria-label="serviceStatusLabel(service)"
+                    :title="serviceStatusLabel(service)"
+                    role="img"
+                    >mdi-circle</v-icon
+                  >
+                  {{ service.label }}
                 </v-btn>
                 <v-spacer />
                 <v-btn
@@ -193,6 +189,13 @@ export default {
     },
   },
   methods: {
+    serviceStatusColor(service) {
+      return service.status === "healthy" ? "green" : "red";
+    },
+    serviceStatusLabel(service) {
+      const availability = service.status === "healthy" ? "available" : "unhealthy";
+      return `${service.label} is ${availability}`;
+    },
     startStatusPolling() {
       const fetchStatus = () => {
         this.loadMagicCastlesStatus();

--- a/mchub/models/magic_castle/magic_castle.py
+++ b/mchub/models/magic_castle/magic_castle.py
@@ -384,7 +384,8 @@ class MagicCastle:
     @property
     def services_are_online(self):
         return all(
-            status == "healthy" for status in self.service_statuses.values()
+            ProvisioningManager.service_is_healthy(service)
+            for service in self.service_statuses.values()
         )
 
     @property

--- a/mchub/models/puppet/provisioning_manager.py
+++ b/mchub/models/puppet/provisioning_manager.py
@@ -16,33 +16,53 @@ class ProvisioningManager:
     """
 
     SERVICES = {
-        "jupyterhub": ("jupyter", 405),
-        "freeipa": ("ipa", 301),
-        "mokey": ("mokey", 405),
+        "jupyterhub": {
+            "label": "JupyterHub",
+            "subdomain": "jupyter",
+            "expected_status": 405,
+        },
+        "freeipa": {
+            "label": "FreeIPA",
+            "subdomain": "ipa",
+            "expected_status": 301,
+        },
+        "mokey": {
+            "label": "Mokey",
+            "subdomain": "mokey",
+            "expected_status": 405,
+        },
     }
 
     @classmethod
     def check_services(cls, hostname):
         statuses = {}
-        for service, (subdomain, expected_status) in cls.SERVICES.items():
+        for service, config in cls.SERVICES.items():
+            url = f"https://{config['subdomain']}.{hostname}"
             try:
-                response = requests.head(
-                    f"https://{subdomain}.{hostname}", timeout=0.1, verify=True
-                )
-                statuses[service] = (
+                response = requests.head(url, timeout=0.1, verify=True)
+                status = (
                     "healthy"
-                    if response.status_code == expected_status
+                    if response.status_code == config["expected_status"]
                     else "unavailable"
                 )
             except RequestException:
-                statuses[service] = "unavailable"
+                status = "unavailable"
+            statuses[service] = {
+                "label": config["label"],
+                "url": url,
+                "status": status,
+            }
         return statuses
+
+    @staticmethod
+    def service_is_healthy(service):
+        return service["status"] == "healthy"
 
     @classmethod
     def check_online(cls, hostname):
         return all(
-            status == "healthy"
-            for status in cls.check_services(hostname).values()
+            cls.service_is_healthy(service)
+            for service in cls.check_services(hostname).values()
         )
 
     @staticmethod
@@ -51,7 +71,8 @@ class ProvisioningManager:
             return "unknown"
 
         healthy_services = sum(
-            status == "healthy" for status in service_statuses.values()
+            ProvisioningManager.service_is_healthy(service)
+            for service in service_statuses.values()
         )
         if healthy_services == len(service_statuses):
             return "healthy"

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -82,9 +82,21 @@ EXISTING_CLUSTER_STATE = {
     "status": "provisioning_success",
     "health": "healthy",
     "services": {
-        "jupyterhub": "healthy",
-        "freeipa": "healthy",
-        "mokey": "healthy",
+        "jupyterhub": {
+            "label": "JupyterHub",
+            "url": "https://jupyter.valid1.magic-castle.cloud",
+            "status": "healthy",
+        },
+        "freeipa": {
+            "label": "FreeIPA",
+            "url": "https://ipa.valid1.magic-castle.cloud",
+            "status": "healthy",
+        },
+        "mokey": {
+            "label": "Mokey",
+            "url": "https://mokey.valid1.magic-castle.cloud",
+            "status": "healthy",
+        },
     },
     "hostname": "valid1.magic-castle.cloud",
     "freeipa_passwd": "FAKE",
@@ -365,9 +377,21 @@ CLUSTERS = {
         "status": "provisioning_success",
         "health": "healthy",
         "services": {
-            "jupyterhub": "healthy",
-            "freeipa": "healthy",
-            "mokey": "healthy",
+            "jupyterhub": {
+                "label": "JupyterHub",
+                "url": "https://jupyter.valid1.magic-castle.cloud",
+                "status": "healthy",
+            },
+            "freeipa": {
+                "label": "FreeIPA",
+                "url": "https://ipa.valid1.magic-castle.cloud",
+                "status": "healthy",
+            },
+            "mokey": {
+                "label": "Mokey",
+                "url": "https://mokey.valid1.magic-castle.cloud",
+                "status": "healthy",
+            },
         },
         "freeipa_passwd": "FAKE",
         "age": "a moment",
@@ -417,9 +441,21 @@ CLUSTERS = {
         "status": "provisioning_success",
         "health": "healthy",
         "services": {
-            "jupyterhub": "healthy",
-            "freeipa": "healthy",
-            "mokey": "healthy",
+            "jupyterhub": {
+                "label": "JupyterHub",
+                "url": "https://jupyter.noowner.magic-castle.cloud",
+                "status": "healthy",
+            },
+            "freeipa": {
+                "label": "FreeIPA",
+                "url": "https://ipa.noowner.magic-castle.cloud",
+                "status": "healthy",
+            },
+            "mokey": {
+                "label": "Mokey",
+                "url": "https://mokey.noowner.magic-castle.cloud",
+                "status": "healthy",
+            },
         },
         "freeipa_passwd": "FAKE",
         "age": "a moment",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -44,14 +44,27 @@ def app(config_mock, generate_test_clusters, mocker):
     from mchub.models.puppet.provisioning_manager import ProvisioningManager
     from mchub.models.user import UserORM
 
+    def healthy_services(hostname):
+        return {
+            "jupyterhub": {
+                "label": "JupyterHub",
+                "url": f"https://jupyter.{hostname}",
+                "status": "healthy",
+            },
+            "freeipa": {
+                "label": "FreeIPA",
+                "url": f"https://ipa.{hostname}",
+                "status": "healthy",
+            },
+            "mokey": {
+                "label": "Mokey",
+                "url": f"https://mokey.{hostname}",
+                "status": "healthy",
+            },
+        }
+
     mocker.patch.object(
-        ProvisioningManager,
-        "check_services",
-        return_value={
-            "jupyterhub": "healthy",
-            "freeipa": "healthy",
-            "mokey": "healthy",
-        },
+        ProvisioningManager, "check_services", side_effect=healthy_services
     )
 
     app = create_app(db_path="sqlite:///:memory:")

--- a/tests/unit/magic_castle/test_magic_castle.py
+++ b/tests/unit/magic_castle/test_magic_castle.py
@@ -173,9 +173,21 @@ def test_successful_provisioning_is_not_reclassified_when_a_service_stops(
         ProvisioningManager,
         "check_services",
         return_value={
-            "jupyterhub": "unavailable",
-            "freeipa": "healthy",
-            "mokey": "healthy",
+            "jupyterhub": {
+                "label": "JupyterHub",
+                "url": "https://jupyter.valid1.magic-castle.cloud",
+                "status": "unavailable",
+            },
+            "freeipa": {
+                "label": "FreeIPA",
+                "url": "https://ipa.valid1.magic-castle.cloud",
+                "status": "healthy",
+            },
+            "mokey": {
+                "label": "Mokey",
+                "url": "https://mokey.valid1.magic-castle.cloud",
+                "status": "healthy",
+            },
         },
     )
 
@@ -183,7 +195,7 @@ def test_successful_provisioning_is_not_reclassified_when_a_service_stops(
 
     assert cluster.status == ClusterStatusCode.PROVISIONING_SUCCESS
     assert cluster.health == "degraded"
-    assert cluster.service_statuses["jupyterhub"] == "unavailable"
+    assert cluster.service_statuses["jupyterhub"]["status"] == "unavailable"
 
 
 def test_destroyed_cluster_state_archives_github_repo(app, mocker):


### PR DESCRIPTION
- Backend service registry now defines each service’s label, URL subdomain, expected response, and health (mchub/models/puppet/provisioning_manager.py:18).
- API service entries include label, url, and status.
- UI uses a single v-for to render all reported services and their green/red indicators (frontend/src/components/cluster/ClustersList.vue:84).
- Adding a monitored service now only requires another backend registry entry.