### PR TITLE
Fix transition issue when accepting first plan

### DIFF
--- a/frontend/src/components/cluster/ClusterDisplay.vue
+++ b/frontend/src/components/cluster/ClusterDisplay.vue
@@ -160,6 +160,7 @@ export default {
       magicCastle: null,
       loading: false,
       statusPromise: null,
+      applyRequested: false,
       stateful: false,
     };
   },
@@ -190,14 +191,18 @@ export default {
       return this.creationSteps.findIndex((step) => step.id === this.creationStep);
     },
     busy() {
-      return [
-        ClusterStatusCode.DESTROY_RUNNING,
-        ClusterStatusCode.BUILD_RUNNING,
-        ClusterStatusCode.PLAN_RUNNING,
-      ].includes(this.status);
+      return (
+        this.applyRequested ||
+        [ClusterStatusCode.DESTROY_RUNNING, ClusterStatusCode.BUILD_RUNNING, ClusterStatusCode.PLAN_RUNNING].includes(
+          this.status
+        )
+      );
     },
     applyRunning() {
-      return [ClusterStatusCode.DESTROY_RUNNING, ClusterStatusCode.BUILD_RUNNING].includes(this.status);
+      return (
+        this.applyRequested ||
+        [ClusterStatusCode.DESTROY_RUNNING, ClusterStatusCode.BUILD_RUNNING].includes(this.status)
+      );
     },
     existingCluster() {
       return this.hostname !== null && this.hostname !== undefined;
@@ -217,14 +222,36 @@ export default {
       }
       const statusAlreadyInitialized = this.status !== null;
       const planWasRunning = this.status === ClusterStatusCode.PLAN_RUNNING;
+      const applyWasRequested = this.applyRequested;
 
       this.statusPromise = MagicCastleRepository.getStatus(this.hostname);
-      const { status, health, stateful, progress } = (await this.statusPromise).data;
-      this.statusPromise = null;
+      let response;
+      try {
+        response = await this.statusPromise;
+      } finally {
+        this.statusPromise = null;
+      }
+      // A poll started before confirmation must not overwrite the accepted plan.
+      if (!applyWasRequested && this.applyRequested) {
+        return;
+      }
+      const { status, health, stateful, progress } = response.data;
+      if (
+        ![
+          ClusterStatusCode.CREATED,
+          ClusterStatusCode.PLAN_RUNNING,
+          ClusterStatusCode.BUILD_RUNNING,
+          ClusterStatusCode.DESTROY_RUNNING,
+        ].includes(status)
+      ) {
+        this.applyRequested = false;
+      }
       this.status = status;
       this.health = health;
       this.stateful = stateful;
-      this.resourcesChanges = progress || [];
+      if (!this.applyRequested || progress?.length) {
+        this.resourcesChanges = progress || [];
+      }
 
       if (!this.busy) {
         this.stopStatusPolling();
@@ -232,7 +259,7 @@ export default {
           this.goHome();
           return;
         }
-        if (statusAlreadyInitialized && !planWasRunning) {
+        if (applyWasRequested || (statusAlreadyInitialized && !planWasRunning)) {
           // We avoid displaying any status dialog after plan generation,
           // because the new status may be the same as before the plan creation.
           this.showStatusDialog();
@@ -241,11 +268,13 @@ export default {
       }
     },
     startStatusPolling() {
+      this.stopStatusPolling();
       this.statusPoller = setInterval(this.fetchStatus, POLL_STATUS_INTERVAL);
       this.fetchStatus();
     },
     stopStatusPolling() {
       clearInterval(this.statusPoller);
+      this.statusPoller = null;
     },
     showStatusDialog() {
       switch (this.status) {
@@ -334,10 +363,12 @@ export default {
       }
     },
     async applyCluster() {
+      this.applyRequested = true;
       try {
         await MagicCastleRepository.apply(this.hostname);
         this.startStatusPolling();
       } catch (e) {
+        this.applyRequested = false;
         this.showError(e.response.data.message);
       }
     },
@@ -438,6 +469,7 @@ export default {
       return new Promise((resolve) => setTimeout(resolve, ms));
     },
     unloadCluster() {
+      this.applyRequested = false;
       this.magicCastle = null;
       this.status = null;
     },

--- a/frontend/tests/unit/components/cluster/ClusterDisplay.spec.js
+++ b/frontend/tests/unit/components/cluster/ClusterDisplay.spec.js
@@ -5,9 +5,113 @@ import { shallowMount } from "@vue/test-utils";
 
 jest.mock("@/repositories/MagicCastleRepository", () => ({
   getStatus: jest.fn(),
+  apply: jest.fn(),
+  getState: jest.fn(),
 }));
 
 describe("ClusterDisplay", () => {
+  const mountDisplay = () =>
+    shallowMount(
+      { ...ClusterDisplay, created() {} },
+      {
+        propsData: { hostname: "test.example.com" },
+        data: () => ({
+          status: ClusterStatusCode.CREATED,
+          magicCastle: {},
+          resourcesChanges: [{ address: "test", change: { actions: ["create"], progress: "queued" } }],
+        }),
+        stubs: [
+          "v-container",
+          "v-card",
+          "v-card-title",
+          "v-card-text",
+          "v-list",
+          "v-list-item",
+          "v-list-item-content",
+          "v-list-item-subtitle",
+          "v-list-item-title",
+          "v-divider",
+        ],
+      }
+    );
+
+  it("keeps the accepted plan visible and polls through delayed apply statuses", async () => {
+    jest.useFakeTimers();
+    let acceptApply;
+    MagicCastleRepository.apply.mockReturnValue(
+      new Promise((resolve) => {
+        acceptApply = resolve;
+      })
+    );
+    MagicCastleRepository.getStatus.mockResolvedValue({ data: { status: ClusterStatusCode.PLAN_RUNNING } });
+    MagicCastleRepository.getState.mockResolvedValue({ data: {} });
+    const wrapper = mountDisplay();
+    const applying = wrapper.vm.applyCluster();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findComponent({ name: "ClusterEditor" }).exists()).toBe(false);
+    expect(wrapper.findComponent({ name: "ClusterResources" }).props("showProgress")).toBe(true);
+    acceptApply({});
+    await applying;
+
+    for (const status of [ClusterStatusCode.PLAN_RUNNING, ClusterStatusCode.CREATED, ClusterStatusCode.BUILD_RUNNING]) {
+      MagicCastleRepository.getStatus.mockResolvedValue({ data: { status } });
+      await wrapper.vm.fetchStatus();
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.statusPoller).not.toBeNull();
+      expect(wrapper.findComponent({ name: "ClusterEditor" }).exists()).toBe(false);
+      expect(wrapper.vm.resourcesChanges).toHaveLength(1);
+    }
+
+    MagicCastleRepository.getStatus.mockResolvedValue({ data: { status: ClusterStatusCode.PROVISIONING_RUNNING } });
+    await wrapper.vm.fetchStatus();
+    expect(wrapper.vm.applyRequested).toBe(false);
+    expect(wrapper.vm.statusPoller).toBeNull();
+    expect(wrapper.vm.provisioningRunningDialog).toBe(true);
+    wrapper.destroy();
+    jest.useRealTimers();
+  });
+
+  it("ignores a status response that started before plan acceptance", async () => {
+    let resolveStatus;
+    MagicCastleRepository.getStatus.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStatus = resolve;
+      })
+    );
+    const wrapper = mountDisplay();
+    const polling = wrapper.vm.fetchStatus();
+    wrapper.vm.applyRequested = true;
+    resolveStatus({ data: { status: ClusterStatusCode.CREATED, progress: [] } });
+    await polling;
+    expect(wrapper.vm.applyRequested).toBe(true);
+    expect(wrapper.vm.resourcesChanges).toHaveLength(1);
+    expect(wrapper.vm.statusPromise).toBeNull();
+    wrapper.destroy();
+  });
+
+  it("shows completion when apply finishes between polls", async () => {
+    MagicCastleRepository.getStatus.mockResolvedValue({
+      data: { status: ClusterStatusCode.PROVISIONING_RUNNING },
+    });
+    MagicCastleRepository.getState.mockResolvedValue({ data: {} });
+    const wrapper = mountDisplay();
+    await wrapper.setData({ applyRequested: true, status: ClusterStatusCode.PLAN_RUNNING });
+    await wrapper.vm.fetchStatus();
+    expect(wrapper.vm.applyRequested).toBe(false);
+    expect(wrapper.vm.provisioningRunningDialog).toBe(true);
+    wrapper.destroy();
+  });
+
+  it("returns to the editor with an error when apply is rejected", async () => {
+    MagicCastleRepository.apply.mockRejectedValue({ response: { data: { message: "Apply failed" } } });
+    const wrapper = mountDisplay();
+    await wrapper.vm.applyCluster();
+    expect(wrapper.vm.applyRequested).toBe(false);
+    expect(wrapper.vm.errorMessage).toBe("Apply failed");
+    expect(wrapper.findComponent({ name: "ClusterEditor" }).exists()).toBe(true);
+    wrapper.destroy();
+  });
+
   it("renders completed, active, and pending setup steps", () => {
     const wrapper = shallowMount(
       { ...ClusterDisplay, created() {} },


### PR DESCRIPTION
Temporary server statuses no longer bring back the creation form or stop polling; the progress list stays visible while apply runs.